### PR TITLE
Chunky csv handling

### DIFF
--- a/bill_hicks.gemspec
+++ b/bill_hicks.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency  "smarter_csv", "~> 1.1.4"
+
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 11.3"
   spec.add_development_dependency "rspec", "~> 3.5"

--- a/lib/bill_hicks.rb
+++ b/lib/bill_hicks.rb
@@ -2,6 +2,7 @@ require 'bill_hicks/version'
 
 require 'csv'
 require 'net/ftp'
+require 'smarter_csv'
 
 require 'bill_hicks/base'
 require 'bill_hicks/catalog'

--- a/lib/bill_hicks/catalog.rb
+++ b/lib/bill_hicks/catalog.rb
@@ -67,13 +67,16 @@ module BillHicks
     # @size integer The number of items in each chunk
     def process_as_chunks(size)
       connect(@options) do |ftp|
+        temp_csv_file = Tempfile.new
+
         ftp.chdir(BillHicks.config.top_level_dir)
+        ftp.gettextfile(CATALOG_FILENAME, temp_csv_file.path)
 
-        csv_data = StringIO.new(ftp.gettextfile(CATALOG_FILENAME, nil))
-
-        SmarterCSV.process(csv_data, { :chunk_size => size }) do |chunk|
+        SmarterCSV.process(temp_csv_file, { :chunk_size => size }) do |chunk|
           yield(chunk)
         end
+
+        temp_csv_file.unlink
       end
     end
 

--- a/lib/bill_hicks/inventory.rb
+++ b/lib/bill_hicks/inventory.rb
@@ -53,13 +53,16 @@ module BillHicks
     # @size integer The number of items in each chunk
     def process_as_chunks(size)
       connect(@options) do |ftp|
+        temp_csv_file = Tempfile.new
+
         ftp.chdir(BillHicks.config.top_level_dir)
+        ftp.gettextfile(INVENTORY_FILENAME, temp_csv_file.path)
 
-        csv_data = StringIO.new(ftp.gettextfile(INVENTORY_FILENAME, nil))
-
-        SmarterCSV.process(csv_data, { :chunk_size => size }) do |chunk|
+        SmarterCSV.process(temp_csv_file, { :chunk_size => size }) do |chunk|
           yield(chunk)
         end
+
+        temp_csv_fil.unlink
       end
     end
 

--- a/lib/bill_hicks/inventory.rb
+++ b/lib/bill_hicks/inventory.rb
@@ -20,6 +20,13 @@ module BillHicks
       new(options).all
     end
 
+    def self.process_as_chunks(size = 15, options = {})
+      requires!(options, :username, :password)
+      new(options).process_as_chunks(size) do |chunk|
+        yield(chunk)
+      end
+    end
+
     # Returns an array of hashes with the inventory item details.
     def all
       inventory = []
@@ -39,6 +46,21 @@ module BillHicks
       end
 
       inventory
+    end
+
+    # Streams csv and chunks it
+    #
+    # @size integer The number of items in each chunk
+    def process_as_chunks(size)
+      connect(@options) do |ftp|
+        ftp.chdir(BillHicks.config.top_level_dir)
+
+        csv_data = StringIO.new(ftp.gettextfile(INVENTORY_FILENAME, nil))
+
+        SmarterCSV.process(csv_data, { :chunk_size => size }) do |chunk|
+          yield(chunk)
+        end
+      end
     end
 
   end

--- a/lib/bill_hicks/inventory.rb
+++ b/lib/bill_hicks/inventory.rb
@@ -62,7 +62,7 @@ module BillHicks
           yield(chunk)
         end
 
-        temp_csv_fil.unlink
+        temp_csv_file.unlink
       end
     end
 


### PR DESCRIPTION
These changes allow the chunking of the CSV data pulled from the FTP. You can now easily split the data out into smaller portions to handle as you wish.

Closes #2 